### PR TITLE
Synchronize URLs with Craft's addTrailingSlashesToUrls setting

### DIFF
--- a/varnishpurge/services/VarnishpurgeService.php
+++ b/varnishpurge/services/VarnishpurgeService.php
@@ -222,11 +222,15 @@ class VarnishpurgeService extends BaseApplicationComponent
         }
         
         foreach ($uris as $uri) {
-            if ($uri == '__home__') {
-                array_push($urls, $varnishUrl);
-            } else {
-                array_push($urls, $varnishUrl . $uri);
+            $path = $uri == '__home__' ? '' : $uri;
+            $url = rtrim($varnishUrl, '/').'/'.trim($path, '/');
+
+            if ($path && craft()->config->get('addTrailingSlashesToUrls'))
+            {
+                $url .= '/';
             }
+
+            array_push($urls, $url);
         }
 
         return $urls;


### PR DESCRIPTION
Normally we could just pass everything through `UrlHelper::getUrl()`...but that bypasses the `addTrailingSlashesToUrls` logic if the originating request comes from the cp, which it does in this case.

This circumvented an issue where I had a `addTrailingSlashesToUrls` set `true`, as well as an htaccess rule to add slashes to any incoming requests without them.

The result was my purge requests always going to the non-slashed urls, but I was always serving my slashed ones (either via craft generated links, or handled by the htaccess rewrite).
