### PR TITLE
Use a config.php for cleaner config and populate with defaults.

### DIFF
--- a/varnishpurge/VarnishpurgePlugin.php
+++ b/varnishpurge/VarnishpurgePlugin.php
@@ -9,7 +9,7 @@ class VarnishpurgePlugin extends BasePlugin
     {
         parent::init();
 
-        if (craft()->varnishpurge->getSetting('varnishPurgeEnabled')) { // element saved
+        if (craft()->varnishpurge->getSetting('purgeEnabled')) { // element saved
             craft()->on('elements.onSaveElement', function (Event $event) {
                 craft()->varnishpurge->purgeElement($event->params['element'], craft()->varnishpurge->getSetting('varnishPurgeRelated'));
             });
@@ -41,7 +41,7 @@ class VarnishpurgePlugin extends BasePlugin
     {
         $actions = array();
 
-        if (craft()->varnishpurge->getSetting('varnishPurgeEnabled')) {
+        if (craft()->varnishpurge->getSetting('purgeEnabled')) {
             $purgeAction = craft()->elements->getAction('Varnishpurge_PurgeCache');
 
             $purgeAction->setParams(array(
@@ -58,7 +58,7 @@ class VarnishpurgePlugin extends BasePlugin
     {
         $actions = array();
 
-        if (craft()->varnishpurge->getSetting('varnishPurgeEnabled')) {
+        if (craft()->varnishpurge->getSetting('purgeEnabled')) {
             $purgeAction = craft()->elements->getAction('Varnishpurge_PurgeCache');
 
             $purgeAction->setParams(array(

--- a/varnishpurge/config.php
+++ b/varnishpurge/config.php
@@ -1,0 +1,10 @@
+<?php
+namespace Craft;
+
+return array(
+    'varnishUrl' => craft()->getSiteUrl(),
+    'purgeEnabled' => false,
+    'purgeRelated' => true,
+    'logAll' => 0,
+    'purgeUrlMap' => [],
+);

--- a/varnishpurge/config.php
+++ b/varnishpurge/config.php
@@ -3,7 +3,7 @@ namespace Craft;
 
 return array(
     'varnishUrl' => craft()->getSiteUrl(),
-    'purgeEnabled' => false,
+    'purgeEnabled' => isset($_SERVER['HTTP_X_VARNISH']),
     'purgeRelated' => true,
     'logAll' => 0,
     'purgeUrlMap' => [],

--- a/varnishpurge/elementactions/Varnishpurge_PurgeCacheElementAction.php
+++ b/varnishpurge/elementactions/Varnishpurge_PurgeCacheElementAction.php
@@ -15,7 +15,7 @@ class Varnishpurge_PurgeCacheElementAction extends BaseElementAction
 
     public function performAction(ElementCriteriaModel $criteria)
     {
-			if (craft()->varnishpurge->getSetting('varnishPurgeEnabled')) {
+			if (craft()->varnishpurge->getSetting('purgeEnabled')) {
 				$elements = $criteria->find();
 				craft()->varnishpurge->purgeElements($elements, false);
 				$this->setMessage(Craft::t('Varnish cache was purged.'));

--- a/varnishpurge/services/VarnishpurgeService.php
+++ b/varnishpurge/services/VarnishpurgeService.php
@@ -13,8 +13,8 @@ class VarnishpurgeService extends BaseApplicationComponent
     public function purgeElement($element, $purgeRelated = true)
     {
         $this->purgeElements(array($element), $purgeRelated);
-    }    
-    
+    }
+
     /**
      * Purge an array of elements
      *
@@ -25,22 +25,22 @@ class VarnishpurgeService extends BaseApplicationComponent
         if (count($elements)>0) {
 
             // Assume that we only want to purge elements in one locale.
-            // May not be the case if other thirdparty plugins sends elements. 
+            // May not be the case if other thirdparty plugins sends elements.
             $locale = $elements[0]->locale;
-            
+
             $uris = array();
-            
+
             foreach ($elements as $element) {
                 $uris = array_merge($uris, $this->_getElementUris($element, $locale, $purgeRelated));
             }
-            
+
             $urls = $this->_generateUrls($uris, $locale);
             $urls = array_merge($urls, $this->_getMappedUrls($urls));
-            
+
             if (count($urls) > 0) {
                 $this->_makeTask('Varnishpurge_Purge', $urls, $locale);
             }
-            
+
         }
     }
 
@@ -177,7 +177,7 @@ class VarnishpurgeService extends BaseApplicationComponent
 
             }
         }
-        
+
         return array_unique($uris);
     }
 
@@ -199,28 +199,28 @@ class VarnishpurgeService extends BaseApplicationComponent
     }
 
     /**
-     * 
-     * 
+     *
+     *
      * @param $uris
      * @param $locale
      * @return array
      */
-    private function _generateUrls ($uris, $locale) 
+    private function _generateUrls ($uris, $locale)
     {
         $urls = array();
         $varnishUrlSetting = craft()->varnishpurge->getSetting('varnishUrl');
-        
+
         if (is_array($varnishUrlSetting)) {
             $varnishUrl = $varnishUrlSetting[$locale];
         } else {
             $varnishUrl = $varnishUrlSetting;
         }
-        
+
         if (!$varnishUrl) {
             VarnishpurgePlugin::log('Varnish URL could not be found', LogLevel::Error);
             return $urls;
         }
-        
+
         foreach ($uris as $uri) {
             $path = $uri == '__home__' ? '' : $uri;
             $url = rtrim($varnishUrl, '/').'/'.trim($path, '/');
@@ -237,15 +237,15 @@ class VarnishpurgeService extends BaseApplicationComponent
     }
 
     /**
-     * 
-     * 
+     *
+     *
      * @param $uris
      * @return array
      */
     private function _getMappedUrls($urls) {
         $mappedUrls = array();
-        $map = $this->getSetting('varnishPurgeUrlMap');
-        
+        $map = $this->getSetting('purgeUrlMap');
+
         if (is_array($map)) {
             foreach ($urls as $url) {
                 if (isset($map[$url])) {
@@ -259,10 +259,10 @@ class VarnishpurgeService extends BaseApplicationComponent
                 }
             }
         }
-        
+
         return $mappedUrls;
     }
-    
+
     /**
      * Create task for purging urls
      *
@@ -274,8 +274,8 @@ class VarnishpurgeService extends BaseApplicationComponent
     private function _makeTask($taskName, $urls, $locale)
     {
         $urls = array_unique($urls);
-        
-        VarnishpurgePlugin::log('Creating task (' . $taskName . ', ' . implode(',', $urls) . ', ' . $locale . ')', LogLevel::Info, craft()->varnishpurge->getSetting('varnishLogAll'));
+
+        VarnishpurgePlugin::log('Creating task (' . $taskName . ', ' . implode(',', $urls) . ', ' . $locale . ')', LogLevel::Info, craft()->varnishpurge->getSetting('logAll'));
 
         // If there are any pending tasks, just append the paths to it
         $task = craft()->tasks->getNextPendingTask($taskName);
@@ -307,8 +307,8 @@ class VarnishpurgeService extends BaseApplicationComponent
         }
 
     }
-    
-    
+
+
     /**
      * Gets a plugin setting
      *
@@ -318,28 +318,7 @@ class VarnishpurgeService extends BaseApplicationComponent
      */
     public function getSetting($name)
     {
-        $this->settings = $this->_initSettings();
-        return $this->settings[$name];
+        return craft()->config->get($name, 'varnishpurge');
     }
-
-
-    /**
-     * Gets settings from config
-     *
-     * @return array Array containing all settings
-     * @author André Elvan
-     */
-    private function _initSettings()
-    {
-        $settings = array();
-        $settings['varnishPurgeEnabled'] = craft()->config->get('varnishPurgeEnabled');
-        $settings['varnishPurgeRelated'] = craft()->config->get('varnishPurgeRelated');
-        $settings['varnishUrl'] = craft()->config->get('varnishUrl');
-        $settings['varnishLogAll'] = craft()->config->get('varnishLogAll');
-        $settings['varnishPurgeUrlMap'] = craft()->config->get('varnishPurgeUrlMap');
-
-        return $settings;
-    }
-
 
 }

--- a/varnishpurge/tasks/Varnishpurge_PurgeTask.php
+++ b/varnishpurge/tasks/Varnishpurge_PurgeTask.php
@@ -16,7 +16,7 @@ class Varnishpurge_PurgeTask extends BaseTask
     {
         $urls = $this->getSettings()->urls;
         $this->_locale = $this->getSettings()->locale;
-        
+
         $this->_urls = array();
         $this->_urls = array_chunk($urls, 20);
 
@@ -25,8 +25,8 @@ class Varnishpurge_PurgeTask extends BaseTask
 
     public function runStep($step)
     {
-        VarnishpurgePlugin::log('Varnish purge task run step: ' . $step, LogLevel::Info, craft()->varnishpurge->getSetting('varnishLogAll'));
-        
+        VarnishpurgePlugin::log('Varnish purge task run step: ' . $step, LogLevel::Info, craft()->varnishpurge->getSetting('logAll'));
+
         $batch = \Guzzle\Batch\BatchBuilder::factory()
           ->transferRequests(20)
           ->bufferExceptions()
@@ -36,7 +36,7 @@ class Varnishpurge_PurgeTask extends BaseTask
         $client->setDefaultOption('headers/Accept', '*/*');
 
         foreach ($this->_urls[$step] as $url) {
-            VarnishpurgePlugin::log('Adding url to purge: ' . $url, LogLevel::Info, craft()->varnishpurge->getSetting('varnishLogAll'));
+            VarnishpurgePlugin::log('Adding url to purge: ' . $url, LogLevel::Info, craft()->varnishpurge->getSetting('logAll'));
 
             $request = $client->createRequest('PURGE', $url);
             $batch->add($request);


### PR DESCRIPTION
Since [2.0.2524](https://craftcms.com/changelog#build2524), plugins can have their own `config.php` file instead of sharing with general.php.

I converted your config to this, and set some defaults.