### PR TITLE
Add Commerce products to related purging, simplify element type conditionals

### DIFF
--- a/varnishpurge/services/VarnishpurgeService.php
+++ b/varnishpurge/services/VarnishpurgeService.php
@@ -13,8 +13,8 @@ class VarnishpurgeService extends BaseApplicationComponent
     public function purgeElement($element, $purgeRelated = true)
     {
         $this->purgeElements(array($element), $purgeRelated);
-    }    
-    
+    }
+
     /**
      * Purge an array of elements
      *
@@ -25,22 +25,22 @@ class VarnishpurgeService extends BaseApplicationComponent
         if (count($elements)>0) {
 
             // Assume that we only want to purge elements in one locale.
-            // May not be the case if other thirdparty plugins sends elements. 
+            // May not be the case if other thirdparty plugins sends elements.
             $locale = $elements[0]->locale;
-            
+
             $uris = array();
-            
+
             foreach ($elements as $element) {
                 $uris = array_merge($uris, $this->_getElementUris($element, $locale, $purgeRelated));
             }
-            
+
             $urls = $this->_generateUrls($uris, $locale);
             $urls = array_merge($urls, $this->_getMappedUrls($urls));
-            
+
             if (count($urls) > 0) {
                 $this->_makeTask('Varnishpurge_Purge', $urls, $locale);
             }
-            
+
         }
     }
 
@@ -71,113 +71,54 @@ class VarnishpurgeService extends BaseApplicationComponent
 
         // Get related elements and their uris
         if ($getRelated) {
-            if ($element->getElementType() == ElementType::Entry) {
 
-                // get directly related entries
-                $relatedEntries = $this->_getRelatedElementsOfType($element, $locale, ElementType::Entry);
-                foreach ($relatedEntries as $related) {
-                    if ($related->uri != '') {
-                        $uris[] = $related->uri;
-                    }
-                }
-                unset($relatedEntries);
+	        // get directly related entries
+	        $relatedEntries = $this->_getRelatedElementsOfType($element, $locale, ElementType::Entry);
+	        foreach ($relatedEntries as $related) {
+	            if ($related->uri != '') {
+	                $uris[] = $related->uri;
+	            }
+	        }
+	        unset($relatedEntries);
 
-                // get directly related categories
-                $relatedCategories = $this->_getRelatedElementsOfType($element, $locale, ElementType::Category);
-                foreach ($relatedCategories as $related) {
-                    if ($related->uri != '') {
-                        $uris[] = $related->uri;
-                    }
-                }
-                unset($relatedCategories);
+	        // get directly related categories
+	        $relatedCategories = $this->_getRelatedElementsOfType($element, $locale, ElementType::Category);
+	        foreach ($relatedCategories as $related) {
+	            if ($related->uri != '') {
+	                $uris[] = $related->uri;
+	            }
+	        }
+	        unset($relatedCategories);
 
-                // get directly related matrix block and its owners uri
-                $relatedMatrixes = $this->_getRelatedElementsOfType($element, $locale, ElementType::MatrixBlock);
-                foreach ($relatedMatrixes as $relatedMatrixBlock) {
-                    if ($relatedMatrixBlock->owner->uri != '') {
-                        $uris[] = $relatedMatrixBlock->owner->uri;
-                    }
-                }
-                unset($relatedMatrixes);
+	        // get directly related matrix block and its owners uri
+	        $relatedMatrixes = $this->_getRelatedElementsOfType($element, $locale, ElementType::MatrixBlock);
+	        foreach ($relatedMatrixes as $relatedMatrixBlock) {
+	            if ($relatedMatrixBlock->owner->uri != '') {
+	                $uris[] = $relatedMatrixBlock->owner->uri;
+	            }
+	        }
+	        unset($relatedMatrixes);
 
-            }
+			// get directly related categories
+			$relatedCategories = $this->_getRelatedElementsOfType($element, $locale, ElementType::Category);
+			foreach ($relatedCategories as $related) {
+				if ($related->uri != '') {
+					$uris[] = $related->uri;
+				}
+			}
+			unset($relatedCategories);
 
-            if ($element->getElementType() == ElementType::Category) {
-
-                // get directly related entries
-                $relatedEntries = $this->_getRelatedElementsOfType($element, $locale, ElementType::Entry);
-                foreach ($relatedEntries as $related) {
-                    if ($related->uri != '') {
-                        $uris[] = $related->uri;
-                    }
-                }
-                unset($relatedEntries);
-
-                // get directly related matrix block and its owners uri
-                $relatedMatrixes = $this->_getRelatedElementsOfType($element, $locale, ElementType::MatrixBlock);
-                foreach ($relatedMatrixes as $relatedMatrixBlock) {
-                    if ($relatedMatrixBlock->owner->uri != '') {
-                        $uris[] = $relatedMatrixBlock->owner->uri;
-                    }
-                }
-                unset($relatedMatrixes);
-
-            }
-
-            if ($element->getElementType() == ElementType::MatrixBlock) {
-
-                // get directly related entries
-                $relatedEntries = $this->_getRelatedElementsOfType($element, $locale, ElementType::Entry);
-                foreach ($relatedEntries as $related) {
-                    if ($related->uri != '') {
-                        $uris[] = $related->uri;
-                    }
-                }
-                unset($relatedEntries);
-
-                // get directly related categories
-                $relatedCategories = $this->_getRelatedElementsOfType($element, $locale, ElementType::Category);
-                foreach ($relatedCategories as $related) {
-                    if ($related->uri != '') {
-                        $uris[] = $related->uri;
-                    }
-                }
-                unset($relatedCategories);
-
-            }
-
-            if ($element->getElementType() == ElementType::Asset) {
-
-                // get directly related entries
-                $relatedEntries = $this->_getRelatedElementsOfType($element, $locale, ElementType::Entry);
-                foreach ($relatedEntries as $related) {
-                    if ($related->uri != '') {
-                        $uris[] = $related->uri;
-                    }
-                }
-                unset($relatedEntries);
-
-                // get directly related categories
-                $relatedCategories = $this->_getRelatedElementsOfType($element, $locale, ElementType::Category);
-                foreach ($relatedCategories as $related) {
-                    if ($related->uri != '') {
-                        $uris[] = $related->uri;
-                    }
-                }
-                unset($relatedCategories);
-
-                // get directly related matrix block and its owners uri
-                $relatedMatrixes = $this->_getRelatedElementsOfType($element, $locale, ElementType::MatrixBlock);
-                foreach ($relatedMatrixes as $relatedMatrixBlock) {
-                    if ($relatedMatrixBlock->owner->uri != '') {
-                        $uris[] = $relatedMatrixBlock->owner->uri;
-                    }
-                }
-                unset($relatedMatrixes);
-
-            }
+			// get directly Commerce products
+			$relatedProducts = $this->_getRelatedElementsOfType($element, $locale, 'Commerce_Product');
+			foreach ($relatedProducts as $related) {
+				if ($related->uri != '') {
+					$uris[] = $related->uri;
+				}
+			}
+			unset($relatedProducts);
         }
-        
+
+
         return array_unique($uris);
     }
 
@@ -199,28 +140,28 @@ class VarnishpurgeService extends BaseApplicationComponent
     }
 
     /**
-     * 
-     * 
+     *
+     *
      * @param $uris
      * @param $locale
      * @return array
      */
-    private function _generateUrls ($uris, $locale) 
+    private function _generateUrls ($uris, $locale)
     {
         $urls = array();
         $varnishUrlSetting = craft()->varnishpurge->getSetting('varnishUrl');
-        
+
         if (is_array($varnishUrlSetting)) {
             $varnishUrl = $varnishUrlSetting[$locale];
         } else {
             $varnishUrl = $varnishUrlSetting;
         }
-        
+
         if (!$varnishUrl) {
             VarnishpurgePlugin::log('Varnish URL could not be found', LogLevel::Error);
             return $urls;
         }
-        
+
         foreach ($uris as $uri) {
             $path = $uri == '__home__' ? '' : $uri;
             $url = rtrim($varnishUrl, '/').'/'.trim($path, '/');
@@ -237,15 +178,15 @@ class VarnishpurgeService extends BaseApplicationComponent
     }
 
     /**
-     * 
-     * 
+     *
+     *
      * @param $uris
      * @return array
      */
     private function _getMappedUrls($urls) {
         $mappedUrls = array();
         $map = $this->getSetting('varnishPurgeUrlMap');
-        
+
         if (is_array($map)) {
             foreach ($urls as $url) {
                 if (isset($map[$url])) {
@@ -259,10 +200,10 @@ class VarnishpurgeService extends BaseApplicationComponent
                 }
             }
         }
-        
+
         return $mappedUrls;
     }
-    
+
     /**
      * Create task for purging urls
      *
@@ -274,7 +215,7 @@ class VarnishpurgeService extends BaseApplicationComponent
     private function _makeTask($taskName, $urls, $locale)
     {
         $urls = array_unique($urls);
-        
+
         VarnishpurgePlugin::log('Creating task (' . $taskName . ', ' . implode(',', $urls) . ', ' . $locale . ')', LogLevel::Info, craft()->varnishpurge->getSetting('varnishLogAll'));
 
         // If there are any pending tasks, just append the paths to it
@@ -307,8 +248,8 @@ class VarnishpurgeService extends BaseApplicationComponent
         }
 
     }
-    
-    
+
+
     /**
      * Gets a plugin setting
      *


### PR DESCRIPTION
I didn't see the reason for all the conditionals you had based on `ElementType`.
Seems like regardless of the `ElementType`, you always want to purge anything with a url that is directly related.

I also allowed it to work with `Commerce_Product` elements.