### PR TITLE
Fix/closure vars

### DIFF
--- a/varnishpurge/VarnishpurgePlugin.php
+++ b/varnishpurge/VarnishpurgePlugin.php
@@ -72,18 +72,20 @@ class VarnishpurgePlugin extends BasePlugin
         parent::init();
 
         if (craft()->varnishpurge->getSetting('purgeEnabled')) {
-
             $purgeRelated = craft()->varnishpurge->getSetting('purgeRelated');
 
-            craft()->on('elements.onSaveElement', function (Event $event) use ($purgeRelated) { // element saved
+            craft()->on('elements.onSaveElement', function (Event $event) use ($purgeRelated) {
+                // element saved
                 craft()->varnishpurge->purgeElement($event->params['element'], $purgeRelated);
             });
 
-            craft()->on('entries.onDeleteEntry', function (Event $event) use ($purgeRelated) { //entry deleted
+            craft()->on('entries.onDeleteEntry', function (Event $event) use ($purgeRelated) {
+                //entry deleted
                 craft()->varnishpurge->purgeElement($event->params['entry'], $purgeRelated);
             });
 
-            craft()->on('elements.onBeforePerformAction', function(Event $event) use ($purgeRelated) { //entry deleted via element action
+            craft()->on('elements.onBeforePerformAction', function(Event $event) use ($purgeRelated) {
+                //entry deleted via element action
                 $action = $event->params['action']->classHandle;
                 if ($action == 'Delete') {
                     $elements = $event->params['criteria']->find();

--- a/varnishpurge/VarnishpurgePlugin.php
+++ b/varnishpurge/VarnishpurgePlugin.php
@@ -75,24 +75,24 @@ class VarnishpurgePlugin extends BasePlugin
 
             $purgeRelated = craft()->varnishpurge->getSetting('purgeRelated');
 
-            craft()->on('elements.onSaveElement', function (Event $event) use($purgeRelated) { // element saved
+            craft()->on('elements.onSaveElement', function (Event $event) use ($purgeRelated) { // element saved
                 craft()->varnishpurge->purgeElement($event->params['element'], $purgeRelated);
             });
 
-            craft()->on('entries.onDeleteEntry', function (Event $event) use($purgeRelated) { //entry deleted
+            craft()->on('entries.onDeleteEntry', function (Event $event) use ($purgeRelated) { //entry deleted
                 craft()->varnishpurge->purgeElement($event->params['entry'], $purgeRelated);
             });
 
-    		craft()->on('elements.onBeforePerformAction', function(Event $event) use($purgeRelated) { //entry deleted via element action
-    			$action = $event->params['action']->classHandle;
-    		    if ($action == 'Delete') {
-        		    $elements = $event->params['criteria']->find();
-    		        foreach ($elements as $element) {
-    		            if ($element->elementType !== 'Entry') { return; }
-    					craft()->varnishpurge->purgeElement($element, $purgeRelated);
-    		        }
-    		    }
-    		});
+            craft()->on('elements.onBeforePerformAction', function(Event $event) use ($purgeRelated) { //entry deleted via element action
+                $action = $event->params['action']->classHandle;
+                if ($action == 'Delete') {
+                    $elements = $event->params['criteria']->find();
+                    foreach ($elements as $element) {
+                        if ($element->elementType !== 'Entry') { return; }
+                        craft()->varnishpurge->purgeElement($element, $purgeRelated);
+                    }
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Hey - not sure if you're fine with cold pull requests but I ran this on my PHP 7 sever and it wasn't keen on the use of the `$purgeRelated` variable from outside the function scope. A simple `use` keyword has fixed that, but obviously brings your minimum PHP level up to (I think) 5.3.

Let me know what you think. If you're happy to merge, fine, but otherwise I'll just use this fork for my PHP 7 solutions and pull from your repo for updates.

Great plugin, by the way! 👍 